### PR TITLE
CI: use verify front instead of build

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,4 +31,4 @@ jobs:
     - name: Build with Gradle
       uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
       with:
-        arguments: build
+        arguments: verify -PbuildProfile=front


### PR DESCRIPTION
This builds, tests(including integration tests), and packages front and backend projects.